### PR TITLE
Refactor macro-defined LoadXXXCheckpointer fns to member template fns

### DIFF
--- a/Grid/qcd/hmc/HMCResourceManager.h
+++ b/Grid/qcd/hmc/HMCResourceManager.h
@@ -253,6 +253,20 @@ public:
     }
   }
 
+  /* Load a checkpointer with no attached metadata.
+     HMCResourceManager must have a single checkpointer loaded.
+     Starting a HMC run without a checkpointer loaded,
+     or attempting to load multiple checkpointers,
+     will cause the application to exit with an error.
+
+     Instantiations for built-in checkpointers are below;
+     see LoadBinaryCheckpointer, LoadNerscCheckpointer, LoadILDGCheckpointer,
+     and LoadScidacCheckpointer.
+     To load your own checkpointer,
+     use a line similar to
+
+         TheHMC.Resources.template LoadCheckpointer<MyCheckPointer>(params);
+  */
   template<template<class CPImplementationPolicy> class CheckpointModule>
   void LoadCheckpointer(const CheckpointerParameters& Params_) {
     typedef CheckpointModule<ImplementationPolicy> CPM;
@@ -267,6 +281,9 @@ public:
     }
   }
 
+  /* Load a checkpointer with attached metadata;
+     see the definition of LoadCheckpointer(const CheckpointerParameters& Params_)
+     for further details. */
   template<template<class CPImplementationPolicy, class Metadata> class CheckpointModule, class Metadata>
   void LoadCheckpointer(const CheckpointerParameters& Params_, const Metadata& M_) {
     typedef CheckpointModule<ImplementationPolicy, Metadata> CPM;
@@ -280,6 +297,7 @@ public:
     }
   }
 
+  /* Checkpoint loaders for built-in checkpointers. */
   void LoadBinaryCheckpointer(const CheckpointerParameters& Params_) { LoadCheckpointer<BinaryCPModule>(Params_); }
   void LoadNerscCheckpointer (const CheckpointerParameters& Params_) { LoadCheckpointer<NerscCPModule>(Params_); }
 #ifdef HAVE_LIME

--- a/Grid/qcd/hmc/HMCResourceManager.h
+++ b/Grid/qcd/hmc/HMCResourceManager.h
@@ -266,7 +266,7 @@ public:
       exit(1);
     }
   }
-  
+
   template<template<class CPImplementationPolicy, class Metadata> class CheckpointModule, class Metadata>
   void LoadCheckpointer(const CheckpointerParameters& Params_, const Metadata& M_) {
     typedef CheckpointModule<ImplementationPolicy, Metadata> CPM;
@@ -286,9 +286,9 @@ public:
   void LoadILDGCheckpointer  (const CheckpointerParameters& Params_) { LoadCheckpointer<ILDGCPModule>(Params_); }
 
   template<class Metadata>
-  void LoadScidacCheckpointer(const CheckpointerParameters& Params_, const Metadata&  M_) 
-  { 
-    LoadCheckpointer<ScidacCPModule, Metadata>(Params_, M_); 
+  void LoadScidacCheckpointer(const CheckpointerParameters& Params_, const Metadata&  M_)
+  {
+    LoadCheckpointer<ScidacCPModule, Metadata>(Params_, M_);
   }
 
 #endif

--- a/Grid/qcd/hmc/HMCResourceManager.h
+++ b/Grid/qcd/hmc/HMCResourceManager.h
@@ -32,38 +32,6 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 #include <unordered_map>
 
-// One function per Checkpointer, use a macro to simplify
-#define RegisterLoadCheckPointerFunction(NAME)                           \
-  void Load##NAME##Checkpointer(const CheckpointerParameters& Params_) { \
-    if (!have_CheckPointer) {                                            \
-      std::cout << GridLogDebug << "Loading Checkpointer " << #NAME      \
-                << std::endl;                                            \
-      CP = std::unique_ptr<CheckpointerBaseModule>(                      \
-        new NAME##CPModule<ImplementationPolicy>(Params_));              \
-      have_CheckPointer = true;                                          \
-    } else {                                                             \
-      std::cout << GridLogError << "Checkpointer already loaded "        \
-                << std::endl;                                            \
-      exit(1);                                                           \
-    }                                                                    \
-  }
-
-#define RegisterLoadCheckPointerMetadataFunction(NAME)                   \
-  template < class Metadata >                                            \
-  void Load##NAME##Checkpointer(const CheckpointerParameters& Params_, const Metadata& M_) { \
-    if (!have_CheckPointer) {                                            \
-      std::cout << GridLogDebug << "Loading Metadata Checkpointer " << #NAME      \
-                << std::endl;                                            \
-      CP = std::unique_ptr<CheckpointerBaseModule>(                      \
-        new NAME##CPModule<ImplementationPolicy, Metadata >(Params_, M_));   \
-      have_CheckPointer = true;                                          \
-    } else {                                                             \
-      std::cout << GridLogError << "Checkpointer already loaded "        \
-                << std::endl;                                            \
-      exit(1);                                                           \
-    }                                                                    \
-  }
-
 NAMESPACE_BEGIN(Grid);
 
 // HMC Resource manager
@@ -285,11 +253,44 @@ public:
     }
   }
 
-  RegisterLoadCheckPointerFunction(Binary);
-  RegisterLoadCheckPointerFunction(Nersc);
+  template<template<class CPImplementationPolicy> class CheckpointModule>
+  void LoadCheckpointer(const CheckpointerParameters& Params_) {
+    typedef CheckpointModule<ImplementationPolicy> CPM;
+    if (!have_CheckPointer)
+    {
+      std::cout << GridLogDebug << "Loading Checkpointer " << CPM::Name << std::endl;
+      CP = std::unique_ptr<CheckpointerBaseModule>(new CPM(Params_));
+      have_CheckPointer = true;
+    } else {
+      std::cout << GridLogError << "Checkpointer already loaded " << std::endl;
+      exit(1);
+    }
+  }
+  
+  template<template<class CPImplementationPolicy, class Metadata> class CheckpointModule, class Metadata>
+  void LoadCheckpointer(const CheckpointerParameters& Params_, const Metadata& M_) {
+    typedef CheckpointModule<ImplementationPolicy, Metadata> CPM;
+    if (!have_CheckPointer) {
+      std::cout << GridLogDebug << "Loading Metadata Checkpointer " << CPM::Name << std::endl;
+      CP = std::unique_ptr<CheckpointerBaseModule>( new CPM(Params_, M_));
+      have_CheckPointer = true;
+    } else {
+      std::cout << GridLogError << "Checkpointer already loaded " << std::endl;
+      exit(1);
+    }
+  }
+
+  void LoadBinaryCheckpointer(const CheckpointerParameters& Params_) { LoadCheckpointer<BinaryCPModule>(Params_); }
+  void LoadNerscCheckpointer (const CheckpointerParameters& Params_) { LoadCheckpointer<NerscCPModule>(Params_); }
 #ifdef HAVE_LIME
-  RegisterLoadCheckPointerFunction(ILDG);
-  RegisterLoadCheckPointerMetadataFunction(Scidac);
+  void LoadILDGCheckpointer  (const CheckpointerParameters& Params_) { LoadCheckpointer<ILDGCPModule>(Params_); }
+
+  template<class Metadata>
+  void LoadScidacCheckpointer(const CheckpointerParameters& Params_, const Metadata&  M_) 
+  { 
+    LoadCheckpointer<ScidacCPModule, Metadata>(Params_, M_); 
+  }
+
 #endif
 
   ////////////////////////////////////////////////////////

--- a/Grid/qcd/hmc/checkpointers/CheckPointerModules.h
+++ b/Grid/qcd/hmc/checkpointers/CheckPointerModules.h
@@ -145,7 +145,6 @@ public:
   ScidacCPModule(Reader<ReaderClass>& Reader) : Parametrized<typename CPBase::APar>(Reader), M(Reader){};
 public:
   constexpr static const char* const Name = "Scidac";
-  
 };
 #endif
 

--- a/Grid/qcd/hmc/checkpointers/CheckPointerModules.h
+++ b/Grid/qcd/hmc/checkpointers/CheckPointerModules.h
@@ -65,6 +65,8 @@ public:
   }
 
 private:
+  /* Implementations of initialize() must set CheckPointPtr to an instance of the relevant checkpointer
+     (i.e. child class of BaseHmcCheckpointer). */
   virtual void initialize() = 0;
 
 };

--- a/Grid/qcd/hmc/checkpointers/CheckPointerModules.h
+++ b/Grid/qcd/hmc/checkpointers/CheckPointerModules.h
@@ -96,7 +96,8 @@ class BinaryCPModule: public CheckPointerModule< ImplementationPolicy> {
   virtual void initialize(){
     this->CheckPointPtr.reset(new BinaryHmcCheckpointer<ImplementationPolicy>(this->Par_));
   }
-
+public:
+  constexpr static const char* const Name = "Binary";
 };
 
 
@@ -109,7 +110,8 @@ class NerscCPModule: public CheckPointerModule< ImplementationPolicy> {
   virtual void initialize(){
     this->CheckPointPtr.reset(new NerscHmcCheckpointer<ImplementationPolicy>(this->Par_));
   }
-
+public:
+  constexpr static const char* const Name = "Nersc";
 };
 
 
@@ -124,7 +126,8 @@ class ILDGCPModule: public CheckPointerModule< ImplementationPolicy> {
   virtual void initialize(){
     this->CheckPointPtr.reset(new ILDGHmcCheckpointer<ImplementationPolicy>(this->Par_));
   }
-
+public:
+  constexpr static const char* const Name = "ILDG";
 };
 
 template<class ImplementationPolicy, class Metadata>
@@ -140,6 +143,9 @@ public:
   ScidacCPModule(typename CPBase::APar Par, Metadata M_):M(M_), CPBase(Par) {}
   template <class ReaderClass>
   ScidacCPModule(Reader<ReaderClass>& Reader) : Parametrized<typename CPBase::APar>(Reader), M(Reader){};
+public:
+  constexpr static const char* const Name = "Scidac";
+  
 };
 #endif
 

--- a/Grid/qcd/hmc/checkpointers/CheckPointerModules.h
+++ b/Grid/qcd/hmc/checkpointers/CheckPointerModules.h
@@ -39,6 +39,12 @@ NAMESPACE_BEGIN(Grid);
 template <class ImplementationPolicy>
 class CheckPointerModule: public Parametrized<CheckpointerParameters>, public HMCModuleBase< BaseHmcCheckpointer<ImplementationPolicy> >  {
 public:
+  /* In addition to the virtual method initialize() below,
+     subclasses of CheckPointerModule must define a public attribute
+     constexpr static const char* const Name
+     such that the LoadCheckpointer template method can report which checkpointer it has loaded.
+     Once Grid supports C++20, this may be enforced via concepts. */
+
   std::unique_ptr<BaseHmcCheckpointer<ImplementationPolicy> > CheckPointPtr;
   typedef CheckpointerParameters APar;
   typedef HMCModuleBase< BaseHmcCheckpointer<ImplementationPolicy> > Base;


### PR DESCRIPTION
Replaces the macro-definitions of load checkpointer functions with wrappers around a generic template.
This template can be used to interface the HMCResourceManager with checkpointers that are not defined in Grid, which would remove the need for a divergent fork in order to test alternative serial formats.
