### PR TITLE
Fixed Wilson flow for Nc not equal to 3

### DIFF
--- a/Grid/qcd/action/gauge/GaugeImplTypes.h
+++ b/Grid/qcd/action/gauge/GaugeImplTypes.h
@@ -176,6 +176,8 @@ public:
     Group::ColdConfiguration(pRNG, U);
   }
 
+  static const int num_colours = Group::Dimension;
+
 };
 
 

--- a/Grid/qcd/smearing/WilsonFlow.h
+++ b/Grid/qcd/smearing/WilsonFlow.h
@@ -46,6 +46,13 @@ protected:
 public:
   INHERIT_GIMPL_TYPES(Gimpl)
 
+//Define the action used to evolve the plaquettes
+//(Lüscher: https://arxiv.org/pdf/1006.4518 eq. 1.4)
+//V'(t) = -g^2 * ( d/dVt S[Vt](g) ) * Vt
+//      = -g^2 * ( d/dVt (1/g^2 * sum_p Re tr{ 1 - Vt(p) } ) ) * Vt
+//      = - d/dVt ( sum_p ( Nc - Re tr Vt(p) ) * Vt
+//      = - d/dVt ( Nc * sum_p ( 1 - Re tr Vt(p)/Nc ) ) * Vt
+//      = - d/dVt SG[Vt](Nc) * Vt
   explicit WilsonFlowBase(unsigned int meas_interval =1):
     SG(WilsonGaugeAction<Gimpl>(Gimpl::num_colours)) {
     setDefaultMeasurements(meas_interval);
@@ -138,7 +145,13 @@ public:
 // Implementations
 ////////////////////////////////////////////////////////////////////////////////
 
-//Compute t^E <E(t)> for time from the plaquette form
+//Compute t^2 <E(t)> for time from the plaquette form
+//(Lüscher: https://arxiv.org/pdf/1006.4518 eq. 3.1)
+//E(t) = 2 * sum_p Retr{ 1 - Vt(p) } =
+//     = 2 * sum_p ( Nc - Retr Vt(p) ) =
+//     = 2 * Nc * sum_p ( 1 - Retr Vt(p)/Nc )
+//     = 2 * SG[Vt](Nc)
+//We divide by the volume to get an energy density per site, as is convention
 template <class Gimpl>
 RealD WilsonFlowBase<Gimpl>::energyDensityPlaquette(const RealD t, const GaugeField& U){
   static WilsonGaugeAction<Gimpl> SG(Gimpl::num_colours);
@@ -253,6 +266,11 @@ void WilsonFlow<Gimpl>::smear(GaugeField& out, const GaugeField& in) const{
 
   out = in;
   RealD taus = 0.;
+
+  // Perform initial t=0 measurements
+  for(auto const &meas : this->functions)
+    meas.second(0,taus,out);
+  
   for (unsigned int step = 1; step <= Nstep; step++) { //step indicates the number of smearing steps applied at the time of measurement
     auto start = std::chrono::high_resolution_clock::now();
     evolve_step(out, taus);
@@ -337,6 +355,11 @@ void WilsonFlowAdaptive<Gimpl>::smear(GaugeField& out, const GaugeField& in) con
   RealD taus = 0.;
   RealD eps = init_epsilon;
   unsigned int step = 0;
+
+  // Perform initial t=0 measurements
+  for(auto const &meas : this->functions)
+    meas.second(step,taus,out);
+  
   do{
     int step_success = evolve_step_adaptive(out, taus, eps); 
     step += step_success; //step will not be incremented if the integration step fails

--- a/Grid/qcd/smearing/WilsonFlow.h
+++ b/Grid/qcd/smearing/WilsonFlow.h
@@ -47,8 +47,7 @@ public:
   INHERIT_GIMPL_TYPES(Gimpl)
 
   explicit WilsonFlowBase(unsigned int meas_interval =1):
-    SG(WilsonGaugeAction<Gimpl>(3.0)) {
-    // WilsonGaugeAction with beta 3.0
+    SG(WilsonGaugeAction<Gimpl>(Gimpl::num_colours)) {
     setDefaultMeasurements(meas_interval);
   }
     
@@ -138,9 +137,11 @@ public:
 ////////////////////////////////////////////////////////////////////////////////
 // Implementations
 ////////////////////////////////////////////////////////////////////////////////
+
+//Compute t^E <E(t)> for time from the plaquette form
 template <class Gimpl>
 RealD WilsonFlowBase<Gimpl>::energyDensityPlaquette(const RealD t, const GaugeField& U){
-  static WilsonGaugeAction<Gimpl> SG(3.0);
+  static WilsonGaugeAction<Gimpl> SG(Gimpl::num_colours);
   return 2.0 * t * t * SG.S(U)/U.Grid()->gSites();
 }
 
@@ -252,11 +253,6 @@ void WilsonFlow<Gimpl>::smear(GaugeField& out, const GaugeField& in) const{
 
   out = in;
   RealD taus = 0.;
-
-  // Perform initial t=0 measurements
-  for(auto const &meas : this->functions)
-    meas.second(0,taus,out);
-  
   for (unsigned int step = 1; step <= Nstep; step++) { //step indicates the number of smearing steps applied at the time of measurement
     auto start = std::chrono::high_resolution_clock::now();
     evolve_step(out, taus);
@@ -341,11 +337,6 @@ void WilsonFlowAdaptive<Gimpl>::smear(GaugeField& out, const GaugeField& in) con
   RealD taus = 0.;
   RealD eps = init_epsilon;
   unsigned int step = 0;
-
-  // Perform initial t=0 measurements
-  for(auto const &meas : this->functions)
-    meas.second(step,taus,out);
-  
   do{
     int step_success = evolve_step_adaptive(out, taus, eps); 
     step += step_success; //step will not be incremented if the integration step fails


### PR DESCRIPTION
There is a bug in the current Wilson flow implementation in Grid when compiled for $N_c \neq 3$ . This is because the code makes an assumption in two places that the Wilson gauge action is always $SG ( 3.0 ) $, when in fact this is $SG( N_c )$. This pull request corrects this behaviour by replacing the 3.0 with the number of colours of the group in the `Gimpl.` To achieve this, it was necessary to also expose this number of colours from the `Gimpl`; currently that template parameter is used within the class but not exposed.

The plots attached to this pull request show the behaviour of the bare energy and energy densities in the following cases:

1. Comparison between HiRep and the former _develop_ branch of Grid for the same ensemble of $Sp(4)$ gauge configurations: the curves associated with the implementation in Grid show that the flows generated by using the plaquette and the cloverleaf prescriptions intersect and tend to diverge as the Wilson flow time grows, which is an unexpected behaviour. Accordingly, we found also a significant discrepancy between HiRep and Grid results.

<img width="1000" height="600" alt="sp4_Ebare_develop_vs_HiRep" src="https://github.com/user-attachments/assets/b685e36a-921b-47a2-ab5d-a25ad8c3e703" />
<img width="1000" height="600" alt="sp4_E_develop_vs_HiRep" src="https://github.com/user-attachments/assets/7d9037b1-def4-4813-8bdf-3fc3b389d3c0" />

2. Comparison between HiRep and the new _wflow_sp2n_ branch of Grid for the same ensemble of $Sp(4)$ gauge configurations: after changing $\beta=3$ to the right number of colours, we obtained a perfect match between HiRep and Grid implementations. 

<img width="1000" height="600" alt="sp4_Ebare_wflow_sp2n_vs_HiRep" src="https://github.com/user-attachments/assets/efd45668-c580-49dc-978b-7131a57e3fa1" />
<img width="1000" height="600" alt="sp4_E_wflow_sp2n_vs_HiRep" src="https://github.com/user-attachments/assets/30c9ba02-c551-4fa2-a9e9-e4efd15c6466" />

3.  Comparison between the former _develop_ and the new _wflow_sp2n_ branches of Grid for the same ensemble of $SU(3)$ configurations: since our changes do not affect  the case in which the number of colours is equal to 3, the plots in this case do not show any significant difference, and suggest that the two implementations are the same in the case of $SU(3)$. 

<img width="1000" height="600" alt="su3_Ebare_wflow_sp2n_vs_develop" src="https://github.com/user-attachments/assets/4ddc1a2b-f427-4ab2-93aa-3982208c7d48" />
<img width="1000" height="600" alt="su3_E_wflow_sp2n_vs_develop" src="https://github.com/user-attachments/assets/b3e38a4f-31c3-4b14-b505-7643ac70522d" />

4. Comparison between HiRep and the former _develop_ branch of Grid for the same ensemble of $SU(3)$ configurations: also in this case we did not get any discrepancy between the two implementation for the Wilson flow. 

<img width="1000" height="600" alt="su3_Ebare_wflow_sp2n_vs_HiRep" src="https://github.com/user-attachments/assets/1be4b7b2-8212-4eba-9504-a6bd4a1dc6cc" />
<img width="1000" height="600" alt="su3_E_wflow_sp2n_vs_HiRep" src="https://github.com/user-attachments/assets/3c6c00d3-82ed-49fa-8098-80331fba68d8" />
