### PR TITLE
Acceptance rate observable retrieval

### DIFF
--- a/Grid/qcd/hmc/HMC.h
+++ b/Grid/qcd/hmc/HMC.h
@@ -289,7 +289,7 @@ public:
       	std::cout << GridLogDebug << "Observables # " << obs << std::endl;
       	std::cout << GridLogDebug << "Observables total " << Observables.size() << std::endl;
       	std::cout << GridLogDebug << "Observables pointer " << Observables[obs] << std::endl;
-        Observables[obs]->TrajectoryComplete(traj + 1, TheIntegrator.Smearer, sRNG, pRNG);
+        Observables[obs]->TrajectoryComplete(traj + 1, TheIntegrator.Smearer, sRNG, pRNG, accept);
       }
       std::cout << GridLogHMC << ":::::::::::::::::::::::::::::::::::::::::::" << std::endl;
     }

--- a/Grid/qcd/hmc/HMC.h
+++ b/Grid/qcd/hmc/HMC.h
@@ -93,7 +93,20 @@ struct HMCparameters: Serializable {
 };
 	
 template <class IntegratorType>
-class HybridMonteCarlo {
+class HybridMonteCarlo 
+/*! @brief The HMC class,
+ * which performs the metropolis
+ * accept/reject step and molecular dynamics
+ * integration step.
+ *
+ * As introduced in Duane, Kennedy, Pendleton & Roweth,
+ * Phys. Letters B, 2, 1987
+ * https://doi.org/10.1016/0370-2693(87)91197-X
+ *
+ * See Rothe, Third Edition, Section 16.7
+ * 'The Hybrid Monte Carlo Algorithm'
+ */
+{
 private:
   const HMCparameters Params;
 

--- a/Grid/qcd/observables/hmc_observable.h
+++ b/Grid/qcd/observables/hmc_observable.h
@@ -32,7 +32,20 @@ directory
 NAMESPACE_BEGIN(Grid);
 
 template <class Field>
-class HmcObservable {
+class HmcObservable 
+/*! @brief HMC Observable class,
+ *  HMC observables inherit the method 
+ *  TrajectoryComplete from here, which
+ *  is used to run the computation of
+ *  on-the-fly observables.
+ *
+ *  Expects:
+ *   an integer traj : trajectory number
+ *   a reference to ConfigurationBase : the gauge field configuration
+ *   a reference to a serial RNG
+ *   a reference to a parallel RNG
+ */
+{
  public:
   virtual void TrajectoryComplete(int traj,
                                   ConfigurationBase<Field> &SmartConfig,

--- a/Grid/qcd/observables/hmc_observable.h
+++ b/Grid/qcd/observables/hmc_observable.h
@@ -45,6 +45,25 @@ class HmcObservable {
                                   Field &U,
                                   GridSerialRNG &sRNG,
                                   GridParallelRNG &pRNG) = 0;
+
+  // allow backward compatibility with current observables that do not have 
+  // acceptance argument
+  virtual void TrajectoryComplete(int traj,
+                                  ConfigurationBase<Field> &SmartConfig,
+                                  GridSerialRNG &sRNG,
+                                  GridParallelRNG &pRNG, 
+                                  bool accept)
+  {
+    TrajectoryComplete(traj,SmartConfig,sRNG,pRNG); // Unsmeared observable
+  };
+  virtual void TrajectoryComplete(int traj, 
+                                  Field &U,
+                                  GridSerialRNG &sRNG,
+                                  GridParallelRNG &pRNG,
+                                  bool accept) 
+  {
+    TrajectoryComplete(traj, U, sRNG, pRNG);
+  };
 };
 
 NAMESPACE_END(Grid);

--- a/Grid/qcd/observables/hmc_observable.h
+++ b/Grid/qcd/observables/hmc_observable.h
@@ -67,7 +67,7 @@ class HmcObservable
                                   GridParallelRNG &pRNG, 
                                   bool accept)
   {
-    TrajectoryComplete(traj,SmartConfig,sRNG,pRNG); // Unsmeared observable
+    TrajectoryComplete(traj,SmartConfig.get_U(false),sRNG,pRNG,accept); // Unsmeared observable
   };
   virtual void TrajectoryComplete(int traj, 
                                   Field &U,

--- a/Grid/qcd/observables/hmc_observable.h
+++ b/Grid/qcd/observables/hmc_observable.h
@@ -39,11 +39,16 @@ class HmcObservable
  *  is used to run the computation of
  *  on-the-fly observables.
  *
- *  Expects:
+ *  @details Expects:
  *   an integer traj : trajectory number
  *   a reference to ConfigurationBase : the gauge field configuration
  *   a reference to a serial RNG
  *   a reference to a parallel RNG
+ *   a bool accept (optional):
+ *     whether the proposed update was accepted (true) or rejected (false).
+ *     This will always be supplied by Grid;
+ *     overloads omitting it are present for backward compatibility.
+ *     New code should override the versions taking the accept parameter.
  */
 {
  public:

--- a/Grid/qcd/observables/hmc_observable.h
+++ b/Grid/qcd/observables/hmc_observable.h
@@ -67,7 +67,7 @@ class HmcObservable
                                   GridParallelRNG &pRNG, 
                                   bool accept)
   {
-    TrajectoryComplete(traj,SmartConfig.get_U(false),sRNG,pRNG,accept); // Unsmeared observable
+    TrajectoryComplete(traj,SmartConfig,sRNG,pRNG); // Unsmeared observable
   };
   virtual void TrajectoryComplete(int traj, 
                                   Field &U,


### PR DESCRIPTION
Adds ability to access the acceptance of a step as an observable at `TrajectoryComplete`.

Overload of the standard 4-argument version ensures that this change is non-invasive. Tested on an M1 MacBook Air.