### PR TITLE
Expose gauge group from GImpl

### DIFF
--- a/Grid/qcd/action/gauge/GaugeImplTypes.h
+++ b/Grid/qcd/action/gauge/GaugeImplTypes.h
@@ -78,6 +78,8 @@ public:
   typedef Lattice<SiteLink>    LinkField; 
   typedef Lattice<SiteField>   Field;
 
+  typedef Group GaugeGroup;
+
   // Guido: we can probably separate the types from the HMC functions
   // this will create 2 kind of implementations
   // probably confusing the users


### PR DESCRIPTION
Allows user to access the `Group` class from `GImpl` as follows `GImpl::GaugeGroup`