### PR TITLE
fix bug when using ScidacWriter on non-gauge fields. 

### DIFF
--- a/Grid/parallelIO/IldgIO.h
+++ b/Grid/parallelIO/IldgIO.h
@@ -547,7 +547,7 @@ class ScidacWriter : public GridLimeWriter {
       writeLimeObject(0,0,_scidacRecord,_scidacRecord.SerialisableClassName(),std::string(SCIDAC_PRIVATE_RECORD_XML));
     }
     // Collective call
-    writeLimeLatticeBinaryObject(field,std::string(ILDG_BINARY_DATA),control);      // Closes message with checksum
+    writeLimeLatticeBinaryObject<vobj,GroupName::SU,MatrixFormat::FULL>(field,std::string(ILDG_BINARY_DATA),control);      // Closes message with checksum
   }
 };
 

--- a/Grid/parallelIO/MetaData.h
+++ b/Grid/parallelIO/MetaData.h
@@ -564,11 +564,28 @@ template<class vobj, class group_name, MatrixFormat m_fmt, FloatingPointFormat f
 struct GaugeUnMunger;
 
 // no group reduction
-template<class vobj, class group_name, FloatingPointFormat fp_fmt>
-struct GaugeUnMunger<vobj, group_name, MatrixFormat::FULL, fp_fmt>
-{	
+template<class vobj, class group_name>
+struct GaugeUnMunger<vobj, group_name, MatrixFormat::FULL, FloatingPointFormat::IEEE64BIG>
+{
+  using in_type  = typename vobj::scalar_object;
+  using out_type = typename vobj::scalar_object;
+
+  BinarySimpleUnmunger<out_type, in_type> unmunger;
+
+  void operator() (in_type &in, out_type &out){
+    unmunger(in,out);
+  }
+};
+
+// no group reduction
+// this specialisation only intended to be used by IldgWriter when
+// writing gauge fields.
+template<class vobj, class group_name>
+struct GaugeUnMunger<vobj, group_name, MatrixFormat::FULL, FloatingPointFormat::IEEE32BIG>
+{
   using in_type  = typename vobj::scalar_object; 
-  using out_type = typename std::tuple_element_t<static_cast<int>(fp_fmt), std::tuple<LorentzColourMatrixD,LorentzColourMatrixF>>;
+  using out_type = LorentzColourMatrixF;
+
   BinarySimpleUnmunger<out_type, in_type> unmunger;
 
   void operator() (in_type &in, out_type &out){


### PR DESCRIPTION
This PR fixes a bug I introduced into `ScidacWriter` while extending the `IldgWriter` and `IldgReader` classes. This caused a runtime error whenever you tried to write something other than a gauge field with `ScidacWriter`.

`writeLimeLatticeBinaryObject` is now called with template args inside `ScidacWriter` and I modified `GaugeUnMunger` so that it doesn't require Gauge Field types when `MatrixFormat==MatrixFormat::FULL && FloatingPointFormat==FloatingPointFormat::IEEE64BIG`.

`Test_ildg_io`, `Test_reducedfmt_io` and `Test_mungers_io` all pass and `ScidacWriter` is able to write `LatticePropagator`s.
The `Hadrons` test `Test_field_io` now passes when built against these changes.

There is an upstream bug in `IldgWriter` which causes compilation errors whenever you try to write single precision `LatticeGaugeFieldF`s. These changes don't fix that. There is atleast one place in `Metadata.h` that hard-codes `LatticeColourMatrixD` and at the very least that would need to be changed. 

I think it might be a good idea to separate out the tests for the `ScidacWriter/Reader` into its own `Test_scidac_io.cc`.  
