### PR TITLE
Feature/constrained action

### DIFF
--- a/Grid/qcd/action/gauge/ConstrainedAction.h
+++ b/Grid/qcd/action/gauge/ConstrainedAction.h
@@ -82,6 +82,11 @@ public:
     return constrained_value(wrapped_.Sinitial(U));
   }
 
+  RealD unconstrained(const GaugeField &U)
+  {
+    return wrapped_.S(U);
+  }
+
   virtual void deriv(const GaugeField &U, GaugeField &force)
   {
     RealD base_action = wrapped_.S(U);
@@ -140,7 +145,7 @@ private:
   RealD constrained_value(RealD base_action) const
   {
     RealD displacement = base_action - parameters_.S0;
-    return parameters_.a * base_action + displacement * displacement / (2.0 * parameters_.sigma * parameters_.sigma);
+    return (parameters_.a * base_action) + displacement * displacement / (2.0 * parameters_.sigma * parameters_.sigma);
   }
 };
 

--- a/Grid/qcd/action/gauge/ConstrainedAction.h
+++ b/Grid/qcd/action/gauge/ConstrainedAction.h
@@ -1,0 +1,148 @@
+/*************************************************************************************
+
+Grid physics library, www.github.com/paboyle/Grid
+
+Source file: ConstrainedAction.h
+
+Copyright (C) 2026
+
+Author: Ryan Hill <Ryan.Hill@ed.ac.uk>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+See the full license in the file "LICENSE" in the top level distribution
+directory
+*************************************************************************************/
+/*  END LEGAL */
+#pragma once
+
+#include <cassert>
+#include <sstream>
+
+#include <Grid/qcd/action/ActionBase.h>
+
+NAMESPACE_BEGIN(Grid);
+
+/* Gaussian-constrained action for the LLR algorithm.
+ *
+ * Implements the constrained action
+ *   (beta) S[U] -> aS[U] + (S[U]-S_0)^2/(2 * sigma^2).
+ * given a gauge action S.
+ * Assumes that beta can be freely set to 1 in order to perform
+ * the direct replacement of S[U].
+ */
+struct ConstrainedActionParameters
+{
+  RealD a;     // LLR parameter - tuned to d ln[rho(S)] / dS at S0
+  RealD S0;    // Constraint centre
+  RealD sigma; // Gaussian width
+};
+
+template <class WrappedAction>
+class ConstrainedAction : public Action<typename WrappedAction::GaugeField>
+{
+public:
+  using GaugeField = typename WrappedAction::GaugeField;
+
+  using Action<GaugeField>::S;
+  using Action<GaugeField>::Sinitial;
+  using Action<GaugeField>::deriv;
+  using Action<GaugeField>::refresh;
+
+  ConstrainedAction(WrappedAction &wrapped, ConstrainedActionParameters parameters)
+      : wrapped_(wrapped), parameters_(parameters)
+  {
+    this->is_smeared = wrapped_.is_smeared;
+  }
+
+  virtual void refresh(const GaugeField &U, GridSerialRNG &sRNG, GridParallelRNG &pRNG)
+  {
+    wrapped_.refresh(U, sRNG, pRNG);
+  }
+
+  virtual RealD S(const GaugeField &U)
+  {
+    return constrained_value(wrapped_.S(U));
+  }
+
+  virtual RealD Sinitial(const GaugeField &U)
+  {
+    return constrained_value(wrapped_.Sinitial(U));
+  }
+
+  virtual void deriv(const GaugeField &U, GaugeField &force)
+  {
+    RealD base_action = wrapped_.S(U);
+    wrapped_.deriv(U, force);
+
+    RealD scale = parameters_.a + (base_action - parameters_.S0) / (parameters_.sigma * parameters_.sigma);
+    force *= scale;
+  }
+
+  virtual std::string action_name()
+  {
+    return "ConstrainedAction<" + wrapped_.action_name() + ">";
+  }
+
+  virtual std::string LogParameters()
+  {
+    std::stringstream sstream;
+    sstream << GridLogMessage << "[" << action_name() << "] a:     " << parameters_.a << std::endl;
+    sstream << GridLogMessage << "[" << action_name() << "] S0:    " << parameters_.S0 << std::endl;
+    sstream << GridLogMessage << "[" << action_name() << "] sigma: " << parameters_.sigma << std::endl;
+    sstream << wrapped_.LogParameters();
+    return sstream.str();
+  }
+
+  const ConstrainedActionParameters &parameters() const
+  {
+    return parameters_;
+  }
+
+  void set_parameters(ConstrainedActionParameters parameters)
+  {
+    parameters_ = parameters;
+  }
+
+  void set_a(RealD a)
+  {
+    parameters_.a = a;
+  }
+
+  void set_S0(RealD S0)
+  {
+    parameters_.S0 = S0;
+  }
+
+  void set_sigma(RealD sigma)
+  {
+    ConstrainedActionParameters updated = parameters_;
+    updated.sigma = sigma;
+    parameters_ = updated;
+  }
+
+private:
+  WrappedAction &wrapped_;
+  ConstrainedActionParameters parameters_;
+
+  RealD constrained_value(RealD base_action) const
+  {
+    RealD displacement = base_action - parameters_.S0;
+    return parameters_.a * base_action + displacement * displacement / (2.0 * parameters_.sigma * parameters_.sigma);
+  }
+};
+
+NAMESPACE_END(Grid);
+

--- a/Grid/qcd/action/gauge/ConstrainedAction.h
+++ b/Grid/qcd/action/gauge/ConstrainedAction.h
@@ -82,7 +82,7 @@ public:
     return constrained_value(wrapped_.Sinitial(U));
   }
 
-  RealD unconstrained(const GaugeField &U)
+  RealD Sunconstrained(const GaugeField &U)
   {
     return wrapped_.S(U);
   }
@@ -133,9 +133,7 @@ public:
 
   void set_sigma(RealD sigma)
   {
-    ConstrainedActionParameters updated = parameters_;
-    updated.sigma = sigma;
-    parameters_ = updated;
+    parameters_.sigma = sigma;
   }
 
 private:

--- a/Grid/qcd/action/gauge/Gauge.h
+++ b/Grid/qcd/action/gauge/Gauge.h
@@ -45,6 +45,7 @@ directory
 #include <Grid/qcd/utils/WilsonLoops.h>
 #include <Grid/qcd/action/gauge/WilsonGaugeAction.h>
 #include <Grid/qcd/action/gauge/PlaqPlusRectangleAction.h>
+#include <Grid/qcd/action/gauge/ConstrainedAction.h>
 
 /// \cond DO_NOT_DOCUMENT
 NAMESPACE_BEGIN(Grid);

--- a/Grid/qcd/llr/RobbinsMonroSolver.h
+++ b/Grid/qcd/llr/RobbinsMonroSolver.h
@@ -135,7 +135,7 @@ private:
   void accumulate(int trajectory, Field &U)
   {
     // Accumulation step
-    status_.accumulated_action += action_.unconstrained(U);
+    status_.accumulated_action += action_.Sunconstrained(U);
     if (status_.trajectories_remaining_in_phase > 0) // Ready to update? If not, return to continue sampling.
     {
       return;

--- a/Grid/qcd/llr/RobbinsMonroSolver.h
+++ b/Grid/qcd/llr/RobbinsMonroSolver.h
@@ -2,7 +2,7 @@
 
 Grid physics library, www.github.com/paboyle/Grid
 
-Source file: RobbinsMonroSolverModule.h
+Source file: RobbinsMonroSolver.h
 
 Copyright (C) 2026
 
@@ -136,7 +136,7 @@ private:
   {
     // Accumulation step
     status_.accumulated_action += action_.unconstrained(U);
-    if (status_.trajectories_remaining_in_phase != 0) // Ready to update? If not, return to continue sampling.
+    if (status_.trajectories_remaining_in_phase > 0) // Ready to update? If not, return to continue sampling.
     {
       return;
     }
@@ -148,7 +148,7 @@ private:
     update.mean_action = status_.accumulated_action / parameters_.trajectories_per_update;
     update.residual = update.mean_action - action_.parameters().S0;
     update.previous_a = action_.parameters().a;
-    update.updated_a = update.previous_a - parameters_.gain * update.residual / status_.iteration;
+    update.updated_a = update.previous_a + parameters_.gain * update.residual / (action_.parameters().sigma * action_.parameters().sigma * status_.iteration);
 
     action_.set_a(update.updated_a);
     status_.last_update = update;
@@ -163,7 +163,7 @@ private:
   void thermalise()
   {
     // Only role here is to switch state to 'Accumulating' when # thermalisation steps have passed.
-    if (status_.trajectories_remaining_in_phase == 0)
+    if (status_.trajectories_remaining_in_phase <= 0)
     {
       status_.phase = RobbinsMonroPhase::Accumulating;
       status_.trajectories_remaining_in_phase = parameters_.trajectories_per_update; 

--- a/Grid/qcd/llr/RobbinsMonroSolver.h
+++ b/Grid/qcd/llr/RobbinsMonroSolver.h
@@ -1,0 +1,175 @@
+/*************************************************************************************
+
+Grid physics library, www.github.com/paboyle/Grid
+
+Source file: RobbinsMonroSolverModule.h
+
+Copyright (C) 2026
+
+Author: Ryan Hill <Ryan.Hill@ed.ac.uk>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+See the full license in the file "LICENSE" in the top level distribution
+directory
+*************************************************************************************/
+/*  END LEGAL */
+
+#pragma once
+
+#include <cassert>
+
+#include <Grid/qcd/action/gauge/ConstrainedAction.h>
+
+NAMESPACE_BEGIN(Grid);
+
+enum class RobbinsMonroPhase
+{
+  Thermalising,
+  Accumulating
+};
+
+struct RobbinsMonroParameters
+{
+  int initial_thermalisation_trajectories;
+  int rethermalisation_trajectories;
+  int trajectories_per_update;
+  RealD gain;
+
+  RobbinsMonroParameters(int initial_thermalisation_trajectories = 0,
+                         int rethermalisation_trajectories_ = 0,
+                         int trajectories_per_update_ = 1,
+                         RealD gain_ = 1.0)
+      : initial_thermalisation_trajectories(initial_thermalisation_trajectories),
+        rethermalisation_trajectories(rethermalisation_trajectories_),
+        trajectories_per_update(trajectories_per_update_),
+        gain(gain_)
+  {}
+};
+
+struct RobbinsMonroUpdate
+{
+  int trajectory;
+  int iteration;
+  RealD mean_action;
+  RealD residual;
+  RealD previous_a;
+  RealD updated_a;
+};
+
+struct RobbinsMonroStatus
+{
+  RobbinsMonroPhase phase;
+  int iteration;
+  int trajectories_remaining_in_phase;
+  RealD accumulated_action;
+  RobbinsMonroUpdate last_update;
+};
+
+template <class ConstrainedActionType>
+class RobbinsMonroSolver {
+public:
+  typedef ConstrainedActionType ActionType;
+  typedef typename ActionType::GaugeField Field;
+
+  RobbinsMonroSolver(ActionType &action, RobbinsMonroParameters parameters)
+      : action_(action)
+      , parameters_(parameters)
+      , status_{
+          .phase=RobbinsMonroPhase::Accumulating,
+          .iteration=1,
+          .trajectories_remaining_in_phase=parameters.trajectories_per_update,
+          .accumulated_action=0
+        }
+  {
+    if (parameters_.initial_thermalisation_trajectories != 0)
+    {
+      status_.phase = RobbinsMonroPhase::Thermalising;
+      status_.trajectories_remaining_in_phase = parameters_.initial_thermalisation_trajectories;
+    }
+  }
+
+  void record_configuration(int trajectory, Field &U)
+  {
+    status_.trajectories_remaining_in_phase--;
+    if (status_.phase == RobbinsMonroPhase::Accumulating)
+    {
+      std::cout << GridLogMessage << "RM Phase: Accumulating (remaining trajectories: " << status_.trajectories_remaining_in_phase << ")" << std::endl;
+      accumulate(trajectory, U);
+    }
+    else // Thermalising
+    {
+      std::cout << GridLogMessage << "RM Phase: Thermalising (remaining trajectories: " << status_.trajectories_remaining_in_phase << ")" << std::endl;
+      thermalise();
+    }
+  }
+
+  void record_configuration(int trajectory, ConfigurationBase<Field> &configuration)
+  {
+    Field &U = configuration.get_U(action_.is_smeared);
+    record_configuration(trajectory, U);
+  }
+
+  // Accessors for replica-swapping
+  const RobbinsMonroParameters &parameters() const { return parameters_; }
+  void restore_state(const RobbinsMonroStatus &state) { status_ = state; }
+  RobbinsMonroStatus status() const { return status_; }
+public:
+  ActionType &action_;
+private:
+  RobbinsMonroParameters parameters_;
+  RobbinsMonroStatus status_;
+
+  void accumulate(int trajectory, Field &U)
+  {
+    // Accumulation step
+    status_.accumulated_action += action_.unconstrained(U);
+    if (status_.trajectories_remaining_in_phase != 0) // Ready to update? If not, return to continue sampling.
+    {
+      return;
+    }
+
+    // After we've gathered enough samples, perform the update of a.
+    RobbinsMonroUpdate update;
+    update.trajectory = trajectory;
+    update.iteration = status_.iteration;
+    update.mean_action = status_.accumulated_action / parameters_.trajectories_per_update;
+    update.residual = update.mean_action - action_.parameters().S0;
+    update.previous_a = action_.parameters().a;
+    update.updated_a = update.previous_a - parameters_.gain * update.residual / status_.iteration;
+
+    action_.set_a(update.updated_a);
+    status_.last_update = update;
+    ++status_.iteration;
+    status_.accumulated_action = 0.0;
+
+    // Swap over the thermalisation steps to adjust for new value of a.
+    status_.phase = RobbinsMonroPhase::Thermalising;
+    status_.trajectories_remaining_in_phase = parameters_.rethermalisation_trajectories; 
+  }
+
+  void thermalise()
+  {
+    // Only role here is to switch state to 'Accumulating' when # thermalisation steps have passed.
+    if (status_.trajectories_remaining_in_phase == 0)
+    {
+      status_.phase = RobbinsMonroPhase::Accumulating;
+      status_.trajectories_remaining_in_phase = parameters_.trajectories_per_update; 
+    }
+  }
+};
+
+NAMESPACE_END(Grid);
+

--- a/Grid/qcd/llr/RobbinsMonroSolverModule.h
+++ b/Grid/qcd/llr/RobbinsMonroSolverModule.h
@@ -1,0 +1,102 @@
+/*************************************************************************************
+
+Grid physics library, www.github.com/paboyle/Grid
+
+Source file: RobbinsMonroSolverModule.h
+
+Copyright (C) 2026
+
+Author: Ryan Hill <Ryan.Hill@ed.ac.uk>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+See the full license in the file "LICENSE" in the top level distribution
+directory
+*************************************************************************************/
+/*  END LEGAL */
+
+#pragma once
+#include <string>
+
+#include <Grid/qcd/llr/RobbinsMonroSolver.h>
+#include <Grid/qcd/observables/hmc_observable.h>
+#include <Grid/qcd/modules/Modules.h>
+
+NAMESPACE_BEGIN(Grid);
+
+inline void LogRobbinsMonroUpdate(const RobbinsMonroUpdate &update,
+                                  const std::string &context)
+{
+  std::cout << GridLogMessage << "[RobbinsMonro" << context << "] trajectory: " << update.trajectory
+            << ", iteration: " << update.iteration
+            << ", mean action: " << update.mean_action
+            << ", residual: " << update.residual
+            << ", a: " << update.previous_a << " -> " << update.updated_a << std::endl;
+}
+
+
+template <class RMSolver>
+class RobbinsMonroSolverModule
+    : public HMCModuleBase<HmcObservable<typename RMSolver::Field> >,
+      public HmcObservable<typename RMSolver::Field> {
+public:
+  typedef typename RMSolver::Field Field;
+  typedef HMCModuleBase<HmcObservable<Field> > Base;
+  typedef typename Base::Product Product;
+
+  explicit RobbinsMonroSolverModule(RMSolver &solver) : solver_(solver) {}
+
+  virtual Product *getPtr()
+  {
+    return this;
+  }
+
+  virtual void TrajectoryComplete(int trajectory, Field &U,
+                                  GridSerialRNG &, GridParallelRNG &)
+  {
+    int previous_iteration = solver_.status().iteration;
+    solver_.record_configuration(trajectory, U);
+    report_update(previous_iteration);
+  }
+
+  virtual void TrajectoryComplete(int trajectory,
+                                  ConfigurationBase<Field> &configuration,
+                                  GridSerialRNG &, GridParallelRNG &,
+                                  bool)
+  {
+    int previous_iteration = solver_.status().iteration;
+    solver_.record_configuration(trajectory, configuration);
+    report_update(previous_iteration);
+  }
+
+private:
+  RMSolver &solver_;
+
+  void report_update(int previous_iteration)
+  {
+    RobbinsMonroStatus status = solver_.status();
+    if (status.iteration == previous_iteration)
+    {
+      return;
+    }
+
+    LogRobbinsMonroUpdate(status.last_update, "");
+    std::cout << GridLogMessage << "[Action Parameters]" << std::endl;
+    std::cout << solver_.action_.LogParameters();
+  }
+};
+
+NAMESPACE_END(Grid);
+

--- a/tests/core/Test_ConstrainedAction.cc
+++ b/tests/core/Test_ConstrainedAction.cc
@@ -1,0 +1,165 @@
+/*************************************************************************************
+
+    Grid physics library, www.github.com/paboyle/Grid
+
+    Source file: ./tests/core/Test_ConstrainedAction.cc
+
+    Copyright (C) 2020 - 2022
+
+    Author: Ryan Hill <Ryan.Hill@ed.ac.uk>
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+    See the full license in the file "LICENSE" in the top level distribution directory
+*************************************************************************************/
+/*  END LEGAL */
+#include <cassert>
+#include <cmath>
+
+#include <Grid/Grid.h>
+
+using namespace Grid;
+
+namespace {
+
+bool isclose(RealD actual, RealD expected, RealD relative_tolerance)
+{
+  return std::abs(actual - expected) <= relative_tolerance * (1.0 + std::abs(expected));
+}
+
+void assert_force_matches(const LatticeGaugeField &actual,
+                          const LatticeGaugeField &expected,
+                          RealD relative_tolerance)
+{
+  LatticeGaugeField difference(actual.Grid());
+  difference = actual - expected;
+  assert(norm2(difference) <= relative_tolerance * (1.0 + norm2(expected)));
+}
+
+RealD constrained_value(RealD base_action,
+                        const ConstrainedActionParameters &parameters)
+{
+  RealD displacement = base_action - parameters.S0;
+  return parameters.a * base_action + displacement * displacement / (2.0 * parameters.sigma * parameters.sigma);
+}
+
+void assert_action_and_force(WilsonGaugeActionR &wrapped,
+                             ConstrainedAction<WilsonGaugeActionR> &constrained,
+                             const LatticeGaugeField &U,
+                             const ConstrainedActionParameters &parameters)
+{
+  RealD base_action = wrapped.S(U);
+
+  // Check the constrained action value is the stated LLR potential.
+  std::cout << GridLogMessage << "  Constrained action value: " << constrained.S(U) << std::endl;
+  std::cout << GridLogMessage << "  Expected:                 " << constrained_value(base_action, parameters) << std::endl;
+  assert(isclose(constrained.S(U),
+                 constrained_value(base_action, parameters),
+                 1.0e-12));
+
+  // Check the initial action is transformed by the same potential.
+  std::cout << GridLogMessage << "  Constrained initial value: " << constrained.Sinitial(U) << std::endl;
+  std::cout << GridLogMessage << "  Expected:                  " << constrained_value(wrapped.Sinitial(U), parameters) << std::endl;
+  assert(isclose(constrained.Sinitial(U),
+                 constrained_value(wrapped.Sinitial(U), parameters),
+                 1.0e-12));
+
+  LatticeGaugeField base_force(U.Grid());
+  LatticeGaugeField constrained_force(U.Grid());
+  LatticeGaugeField expected_force(U.Grid());
+
+  wrapped.deriv(U, base_force);
+  constrained.deriv(U, constrained_force);
+
+  RealD scale = parameters.a + (base_action - parameters.S0) / (parameters.sigma * parameters.sigma);
+  expected_force = scale * base_force;
+
+  // Check the constrained force obeys the LLR chain rule.
+  assert_force_matches(constrained_force, expected_force, 1.0e-12);
+}
+
+}  // namespace
+
+int main(int argc, char **argv)
+{
+  Grid_init(&argc, &argv);
+
+  Coordinate lattice_size({4, 4, 4, 4});
+  Coordinate simd_layout = GridDefaultSimd(4, vComplex::Nsimd());
+  Coordinate mpi_layout = GridDefaultMpi();
+  GridCartesian grid(lattice_size, simd_layout, mpi_layout);
+
+  GridParallelRNG parallel_rng(&grid);
+  parallel_rng.SeedFixedIntegers({1, 2, 3, 4});
+
+  LatticeGaugeField U(&grid);
+  SU<Nc>::HotConfiguration(parallel_rng, U);
+
+  WilsonGaugeActionR wrapped(1.0);
+  ConstrainedActionParameters parameters{1.7, wrapped.S(U) + 0.25, 2.5};
+  ConstrainedAction<WilsonGaugeActionR> constrained(wrapped, parameters);
+
+  std::cout << GridLogMessage << "--- Test constrained values from constructor ---" << std::endl;
+  assert(!constrained.is_smeared);
+  assert_action_and_force(wrapped, constrained, U, parameters);
+
+  std::cout << GridLogMessage << "--- Test set individual parameters ---" << std::endl;
+  parameters.a = 2.2;
+  constrained.set_a(parameters.a);
+  std::cout << GridLogMessage << "  Expected a: " << parameters.a << std::endl;
+  std::cout << GridLogMessage << "  Actual a:   " << constrained.parameters().a << std::endl;
+  assert_action_and_force(wrapped, constrained, U, parameters);
+
+  parameters.S0 -= 0.4;
+  constrained.set_S0(parameters.S0);
+  std::cout << GridLogMessage << "  Expected S0: " << parameters.S0 << std::endl;
+  std::cout << GridLogMessage << "  Actual S0:   " << constrained.parameters().S0 << std::endl;
+  assert_action_and_force(wrapped, constrained, U, parameters);
+
+  parameters.sigma = 1.75;
+  constrained.set_sigma(parameters.sigma);
+  std::cout << GridLogMessage << "  Expected Sigma: " << parameters.sigma << std::endl;
+  std::cout << GridLogMessage << "  Actual Sigma:   " << constrained.parameters().sigma << std::endl;
+  assert_action_and_force(wrapped, constrained, U, parameters);
+
+  std::cout << GridLogMessage << "--- Test set all parameters ---" << std::endl;
+  parameters = ConstrainedActionParameters{0.8, wrapped.S(U) - 0.5, 1.5};
+  constrained.set_parameters(parameters);
+  std::cout << GridLogMessage << "  Expected a: " << parameters.a << std::endl;
+  std::cout << GridLogMessage << "  Actual a:   " << constrained.parameters().a << std::endl;
+  std::cout << GridLogMessage << "  Expected S0: " << parameters.S0 << std::endl;
+  std::cout << GridLogMessage << "  Actual S0:   " << constrained.parameters().S0 << std::endl;
+  std::cout << GridLogMessage << "  Expected Sigma: " << parameters.sigma << std::endl;
+  std::cout << GridLogMessage << "  Actual Sigma:   " << constrained.parameters().sigma << std::endl;
+  assert(constrained.parameters().a == parameters.a);
+  assert(constrained.parameters().S0 == parameters.S0);
+  assert(constrained.parameters().sigma == parameters.sigma);
+  assert_action_and_force(wrapped, constrained, U, parameters);
+
+  // Check 6: the wrapper propagates smearing and refresh.
+  wrapped.is_smeared = true;
+  ConstrainedAction<WilsonGaugeActionR> smeared_constrained(wrapped, parameters);
+  std::cout << GridLogMessage << "Check setting smear works:" << std::endl;
+  std::cout << GridLogMessage << "  " << smeared_constrained.is_smeared << std::endl;
+  assert(smeared_constrained.is_smeared);
+  wrapped.is_smeared = false;
+
+  GridSerialRNG serial_rng;
+  serial_rng.SeedFixedIntegers({5, 6, 7, 8});
+  constrained.refresh(U, serial_rng, parallel_rng);
+
+  Grid_finalize();
+  return 0;
+}

--- a/tests/llr/Test_constrained_action.cc
+++ b/tests/llr/Test_constrained_action.cc
@@ -4,7 +4,7 @@
 
     Source file: ./tests/core/Test_ConstrainedAction.cc
 
-    Copyright (C) 2020 - 2022
+    Copyright (C) 2026
 
     Author: Ryan Hill <Ryan.Hill@ed.ac.uk>
 

--- a/tests/llr/Test_constrained_action.cc
+++ b/tests/llr/Test_constrained_action.cc
@@ -158,7 +158,8 @@ int main(int argc, char **argv)
 
   GridSerialRNG serial_rng;
   serial_rng.SeedFixedIntegers({5, 6, 7, 8});
-  constrained.refresh(U, serial_rng, parallel_rng);
+  constrained.refresh(U, serial_rng, parallel_rng); // no-op for pure gauge action
+  assert_action_and_force(wrapped, constrained, U, parameters);
 
   Grid_finalize();
   return 0;

--- a/tests/llr/Test_robbins_monro_solver.cc
+++ b/tests/llr/Test_robbins_monro_solver.cc
@@ -79,8 +79,10 @@ int main(int argc, char **argv)
   
   // Robbins-Monro updater
   WilsonGaugeActionR bare_action(1.0);
+  RealD S0    = 1000;
+  RealD sigma = 3.0;
   typedef ConstrainedAction<WilsonGaugeActionR> ConstrainedWilsonGaugeAction;
-  ConstrainedActionParameters action_parameters{.a=1, .S0=1000, .sigma=3.0};
+  ConstrainedActionParameters action_parameters{.a=1, .S0=S0, .sigma=sigma};
   ConstrainedWilsonGaugeAction constrained_action(bare_action, action_parameters);
   typedef RobbinsMonroSolver<ConstrainedWilsonGaugeAction> Solver;
   Solver solver(constrained_action, RobbinsMonroParameters(100, 10, 5, 1.0));
@@ -106,6 +108,9 @@ int main(int argc, char **argv)
 
   TheHMC.ReadCommandLine(argc, argv); // these can be parameters from file
   TheHMC.Run();  // no smearing
+
+  assert(std::abs(constrained_action.parameters().S0 - S0) < 2 * sigma);
+  assert(std::abs(constrained_action.parameters().a - 4.55) < 0.2);
 
   Grid_finalize();
 

--- a/tests/llr/Test_robbins_monro_solver.cc
+++ b/tests/llr/Test_robbins_monro_solver.cc
@@ -1,0 +1,112 @@
+/*************************************************************************************
+
+Grid physics library, www.github.com/paboyle/Grid
+
+Source file: ./tests/Test_llr_robbinsmonro.cc
+
+Copyright (C) 2015, 2026
+
+Author: Peter Boyle <pabobyle@ph.ed.ac.uk>
+Author: neo <cossu@post.kek.jp>
+Author: Guido Cossu <guido.cossu@ed.ac.uk>
+Author: Ryan Hill <guido.cossu@ed.ac.uk>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+See the full license in the file "LICENSE" in the top level distribution
+directory
+*************************************************************************************/
+/*  END LEGAL */
+#include <Grid/Grid.h>
+#include <Grid/qcd/llr/RobbinsMonroSolverModule.h>
+
+int main(int argc, char **argv) 
+{
+  using namespace Grid;
+
+  Grid_init(&argc, &argv);
+  GridLogLayout();
+
+   // Typedefs to simplify notation
+  typedef GenericHMCRunner<MinimumNorm2> HMCWrapper;  // Uses the default minimum norm
+  HMCWrapper TheHMC;
+
+  // Grid from the command line
+  TheHMC.Resources.AddFourDimGrid("gauge");
+
+  // Checkpointer definition
+  CheckpointerParameters CPparams;  
+  CPparams.config_prefix = "ckpoint_lat";
+  CPparams.rng_prefix = "ckpoint_rng";
+  CPparams.saveInterval = 65535;
+  CPparams.format = "IEEE64BIG";
+  
+  TheHMC.Resources.LoadNerscCheckpointer(CPparams);
+
+  RNGModuleParameters RNGpar;
+  RNGpar.serial_seeds = "1 2 3 4 5";
+  RNGpar.parallel_seeds = "6 7 8 9 10";
+  TheHMC.Resources.SetRNGSeeds(RNGpar);
+
+  // Construct observables
+  // here there is too much indirection 
+  typedef PlaquetteMod<HMCWrapper::ImplPolicy> PlaqObs;
+  TheHMC.Resources.AddObservable<PlaqObs>();
+  
+  typedef TopologicalChargeMod<HMCWrapper::ImplPolicy> QObs;
+  TopologyObsParameters TopParams;
+  TopParams.interval = 1;
+  TopParams.do_smearing = false;
+  TopParams.Smearing.init_step_size = 0.01;
+  TopParams.Smearing.tolerance = 1e-5;
+  //  TopParams.Smearing.steps = 200;
+  //  TopParams.Smearing.step_size = 0.01;
+  TopParams.Smearing.meas_interval = 50;
+  TopParams.Smearing.maxTau = 2.0; 
+  TheHMC.Resources.AddObservable<QObs>(TopParams);
+  
+  // Robbins-Monro updater
+  WilsonGaugeActionR bare_action(1.0);
+  typedef ConstrainedAction<WilsonGaugeActionR> ConstrainedWilsonGaugeAction;
+  ConstrainedActionParameters action_parameters{.a=1.0, .S0=10, .sigma=2.0};
+  ConstrainedWilsonGaugeAction constrained_action(bare_action, action_parameters);
+  typedef RobbinsMonroSolver<ConstrainedWilsonGaugeAction> Solver;
+  Solver solver(constrained_action, RobbinsMonroParameters(100, 5, 5, 1.0));
+  typedef RobbinsMonroSolverModule<Solver> RmMod;
+  TheHMC.Resources.AddObservable<RmMod>(solver);
+  //////////////////////////////////////////////
+
+  /////////////////////////////////////////////////////////////
+  // Collect actions, here use more encapsulation
+  // need wrappers of the fermionic classes 
+  // that have a complex construction
+  // standard
+  ActionLevel<HMCWrapper::Field> Level1(1);
+  Level1.push_back(&constrained_action);
+  TheHMC.TheAction.push_back(Level1);
+  /////////////////////////////////////////////////////////////
+
+  // HMC parameters are serialisable
+  TheHMC.Parameters.Trajectories = 205;
+  TheHMC.Parameters.NoMetropolisUntil = 100;
+  TheHMC.Parameters.MD.MDsteps = 20;
+  TheHMC.Parameters.MD.trajL   = 1.0;
+
+  TheHMC.ReadCommandLine(argc, argv); // these can be parameters from file
+  TheHMC.Run();  // no smearing
+
+  Grid_finalize();
+
+} // main

--- a/tests/llr/Test_robbins_monro_solver.cc
+++ b/tests/llr/Test_robbins_monro_solver.cc
@@ -80,10 +80,10 @@ int main(int argc, char **argv)
   // Robbins-Monro updater
   WilsonGaugeActionR bare_action(1.0);
   typedef ConstrainedAction<WilsonGaugeActionR> ConstrainedWilsonGaugeAction;
-  ConstrainedActionParameters action_parameters{.a=1.0, .S0=10, .sigma=2.0};
+  ConstrainedActionParameters action_parameters{.a=1, .S0=1000, .sigma=3.0};
   ConstrainedWilsonGaugeAction constrained_action(bare_action, action_parameters);
   typedef RobbinsMonroSolver<ConstrainedWilsonGaugeAction> Solver;
-  Solver solver(constrained_action, RobbinsMonroParameters(100, 5, 5, 1.0));
+  Solver solver(constrained_action, RobbinsMonroParameters(100, 10, 5, 1.0));
   typedef RobbinsMonroSolverModule<Solver> RmMod;
   TheHMC.Resources.AddObservable<RmMod>(solver);
   //////////////////////////////////////////////
@@ -99,9 +99,9 @@ int main(int argc, char **argv)
   /////////////////////////////////////////////////////////////
 
   // HMC parameters are serialisable
-  TheHMC.Parameters.Trajectories = 205;
-  TheHMC.Parameters.NoMetropolisUntil = 100;
-  TheHMC.Parameters.MD.MDsteps = 20;
+  TheHMC.Parameters.Trajectories = 305;
+  TheHMC.Parameters.NoMetropolisUntil = 0;
+  TheHMC.Parameters.MD.MDsteps = 100;
   TheHMC.Parameters.MD.trajL   = 1.0;
 
   TheHMC.ReadCommandLine(argc, argv); // these can be parameters from file


### PR DESCRIPTION
Draft implementation of the constrained action and Robbins-Monro solver for LLR.
Overall, I think it's a reasonably tidy implementation with a minimal amount of logic (subject to correctness, see below).

Main features/design choices:
- `ConstrainedAction` implemented as an HMC-compatible action templated over a base gauge action; implementation should be compatible with Wilson and PlaqPlusRectangle actions with beta=1.0.
- Robbins-Monro solver implemented as an HMC observable highly coupled to the `ConstrainedAction`, allowing `a` updates
- Robbins-Monro solver is *stateful*, it periodically swaps between estimator-accumulation and thermalisation depending on an internal counter.
- API for the solver should be sufficient for the replica-swapping step.
- Basic test for the constrained action making sure all the setters/getters work
- Basic HMC test showing proof-of-concept for running the Robbins-Monro solver over a constrained Wilson gauge action (takes 60-80s to complete on my laptop for `--grid 4.4.4.4`)

Note:
- Currently a draft; I am not confident this is entirely correct and it has not yet been regressed against either the `llr-wip` branch nor HiRep. I consider this to be a core requirement before merging.
- Related to above, not yet convinced this is going to produce correct answers. The HMC test currently converges to an incorrect value of the action, and `a` runs away without converging.